### PR TITLE
add `at-layer/009` for `@layer` before `@import`

### DIFF
--- a/tests/at-layer/009/README.md
+++ b/tests/at-layer/009/README.md
@@ -1,0 +1,1 @@
+`@layer` should not be reordered after `@import`

--- a/tests/at-layer/009/a.css
+++ b/tests/at-layer/009/a.css
@@ -1,0 +1,5 @@
+@layer a {
+	.box {
+		background-color: red;
+	}
+}

--- a/tests/at-layer/009/b.css
+++ b/tests/at-layer/009/b.css
@@ -1,0 +1,5 @@
+@layer b {
+	.box {
+		background-color: green;
+	}
+}

--- a/tests/at-layer/009/style.css
+++ b/tests/at-layer/009/style.css
@@ -1,0 +1,3 @@
+@layer a;
+@import "b.css";
+@import "a.css";


### PR DESCRIPTION
I don't think this edge case is covered by any of the existing tests.

This is currently a bug with esbuild because it generates the bundle by writing out whole files at a time combined with deleting `@import` rules that point to other files in the bundle. That worked fine before the introduction of `@layer` but that no longer works now that `@layer` rules are allowed before `@import` rules.
